### PR TITLE
Don't automatically install awscli using apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Role Variables
 - jenkins_master_nginx_ssl_s3_access_key: ""
 - jenkins_master_nginx_ssl_s3_secret_key: ""
 - jenkins_master_nginx_ssl_s3_region: "us-east-1"
+- jenkins_master_nginx_ssl_awscli_source: "pip"
 
 See defaults/main.yml for a description of role variables.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,6 +44,7 @@ jenkins_master_nginx_log_dir: /var/log/nginx
 jenkins_master_nginx_unlink_default: false
 
 # SSL files from S3
+jenkins_master_nginx_ssl_awscli_source: pip
 jenkins_master_nginx_ssl_s3_bucket: false
 jenkins_master_nginx_ssl_s3_crt: "{{ jenkins_master_nginx_ssl_crt }}"
 jenkins_master_nginx_ssl_s3_key: "{{ jenkins_master_nginx_ssl_crt }}"

--- a/tasks/install-ssl-files-from-s3.yml
+++ b/tasks/install-ssl-files-from-s3.yml
@@ -1,28 +1,24 @@
 ---
-# this command fails on travis
 - name: install awscli via apt
   become: true
   become_method: sudo
   apt: name=awscli state=present
-  when: jenkins_master_nginx_ssl_s3_bucket
+  when: jenkins_master_nginx_ssl_s3_bucket and jenkins_master_nginx_ssl_awscli_source == "apt"
   ignore_errors: true
   register: apt_awscli
 
-# the next 2 sections will install the AWS CLI via pip in cases where the Ubuntu
-# package attempt above fails. This will happen on Travis CI, but not Ubuntu
-# 14.04 proper
 - name: install pip
   become: true
   become_method: sudo
   apt: name=python-pip state=present
-  when: jenkins_master_nginx_ssl_s3_bucket and apt_awscli is defined and apt_awscli.failed
+  when: jenkins_master_nginx_ssl_s3_bucket and jenkins_master_nginx_ssl_awscli_source == "pip"
   tags: [jenkins-master-nginx-ssl-s3]
 
 - name: install awscli via pip
   become: true
   become_method: sudo
   pip: name=awscli state=present
-  when: jenkins_master_nginx_ssl_s3_bucket and apt_awscli is defined and apt_awscli.failed
+  when: jenkins_master_nginx_ssl_s3_bucket and jenkins_master_nginx_ssl_awscli_source == "pip"
   tags: [jenkins-master-nginx-ssl-s3]
 
 - name: ensure SSL directory exists


### PR DESCRIPTION
### Notes
- awscli on Ubuntu is outdated and may hang on downloads
